### PR TITLE
Protoype for representing SCXML files into diagrams and modify them.

### DIFF
--- a/SCXMLDiagram.design/.classpath
+++ b/SCXMLDiagram.design/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+  <classpathentry kind="src" path="src"/>
+  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+  <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+  <classpathentry kind="output" path="bin"/>
+</classpath>

--- a/SCXMLDiagram.design/.project
+++ b/SCXMLDiagram.design/.project
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>SCXMLDiagram.design</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.acceleo.ide.ui.acceleoBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.acceleo.ide.ui.acceleoNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+	</natures>
+</projectDescription>

--- a/SCXMLDiagram.design/.settings/org.eclipse.jdt.core.prefs
+++ b/SCXMLDiagram.design/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,12 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.methodParameters=do not generate
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.6
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.6

--- a/SCXMLDiagram.design/META-INF/MANIFEST.MF
+++ b/SCXMLDiagram.design/META-INF/MANIFEST.MF
@@ -1,0 +1,16 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: scxml1.design
+Bundle-SymbolicName: SCXMLDiagram.design;singleton:=true
+Bundle-Version: 1.0.0
+Bundle-Activator: scxmlDiagram.design.Activator
+Require-Bundle: org.eclipse.ui,
+ org.eclipse.core.runtime,
+ org.eclipse.core.resources,
+ org.eclipse.sirius,
+ org.eclipse.sirius.common.acceleo.mtl,
+ org.w3c.scxml;bundle-version="1.0.0",
+ org.eclipse.sirius.common;bundle-version="2.0.3"
+Bundle-ActivationPolicy: lazy
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Export-Package: scxmlDiagram.design

--- a/SCXMLDiagram.design/build.properties
+++ b/SCXMLDiagram.design/build.properties
@@ -1,0 +1,7 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .,\
+               description/,\
+               plugin.xml
+customBuildCallbacks = build.acceleo

--- a/SCXMLDiagram.design/description/SCXMLDiagram.odesign
+++ b/SCXMLDiagram.design/description/SCXMLDiagram.odesign
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<description:Group xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:description="http://www.eclipse.org/sirius/description/1.1.0" xmlns:description_1="http://www.eclipse.org/sirius/diagram/description/1.1.0" xmlns:style="http://www.eclipse.org/sirius/diagram/description/style/1.1.0" xmlns:tool="http://www.eclipse.org/sirius/diagram/description/tool/1.1.0" xmlns:tool_1="http://www.eclipse.org/sirius/description/tool/1.1.0" name="SCXMLDiagram" version="8.1.0">
+  <ownedViewpoints name="SCXML">
+    <ownedRepresentations xsi:type="description_1:DiagramDescription" name="Diagram" initialisation="true" domainClass="scxml.ScxmlScxmlType">
+      <defaultLayer name="Default">
+        <nodeMappings name="Initial" preconditionExpression="[initial.oclIsUndefined()->first()=false/]" semanticCandidatesExpression="[thisEObject/]" domainClass="scxml.ScxmlScxmlType">
+          <style xsi:type="style:EllipseNodeDescription" showIcon="false" labelExpression="" resizeKind="NSEW">
+            <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
+          </style>
+        </nodeMappings>
+        <nodeMappings name="Final" labelDirectEdit="//@ownedViewpoints[name='SCXML']/@ownedRepresentations[name='Diagram']/@defaultLayer/@toolSections.0/@ownedTools[name='EditID']" semanticCandidatesExpression="[thisEObject.eContents()/]" domainClass="scxml.ScxmlFinalType">
+          <style xsi:type="style:EllipseNodeDescription" labelExpression="feature:id" resizeKind="NSEW">
+            <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='green']"/>
+          </style>
+        </nodeMappings>
+        <edgeMappings name="InitialTransition" sourceMapping="//@ownedViewpoints[name='SCXML']/@ownedRepresentations[name='Diagram']/@defaultLayer/@nodeMappings[name='Initial']" targetMapping="//@ownedViewpoints[name='SCXML']/@ownedRepresentations[name='Diagram']/@defaultLayer/@containerMappings[name='State'] //@ownedViewpoints[name='SCXML']/@ownedRepresentations[name='Diagram']/@defaultLayer/@containerMappings[name='Parallel']" targetFinderExpression="[eContents()->select(e|(e.oclIsKindOf(scxml::ScxmlStateType) and e.oclAsType(scxml::ScxmlStateType).id=self.initial->first().toString()) or (e.oclIsKindOf(scxml::ScxmlParallelType) and e.oclAsType(scxml::ScxmlParallelType).id=self.initial->first().toString()))/]" sourceFinderExpression="[thisEObject/]" domainClass="scxml.ScxmlScxmlType" useDomainElement="true">
+          <style targetArrow="InputFillClosedArrow" sizeComputationExpression="2">
+            <strokeColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
+            <centerLabelStyleDescription>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            </centerLabelStyleDescription>
+          </style>
+        </edgeMappings>
+        <edgeMappings name="Transition" labelDirectEdit="//@ownedViewpoints[name='SCXML']/@ownedRepresentations[name='Diagram']/@defaultLayer/@toolSections.0/@ownedTools[name='EditTransitionLabel']" sourceMapping="//@ownedViewpoints[name='SCXML']/@ownedRepresentations[name='Diagram']/@defaultLayer/@containerMappings[name='State'] //@ownedViewpoints[name='SCXML']/@ownedRepresentations[name='Diagram']/@defaultLayer/@containerMappings[name='Parallel']" targetMapping="//@ownedViewpoints[name='SCXML']/@ownedRepresentations[name='Diagram']/@defaultLayer/@containerMappings[name='State'] //@ownedViewpoints[name='SCXML']/@ownedRepresentations[name='Diagram']/@defaultLayer/@containerMappings[name='Parallel'] //@ownedViewpoints[name='SCXML']/@ownedRepresentations[name='Diagram']/@defaultLayer/@nodeMappings[name='Final']" targetFinderExpression="[eContainer(scxml::ScxmlScxmlType).eAllContents()->select(e|(e.oclIsKindOf(scxml::ScxmlStateType) and e.oclAsType(scxml::ScxmlStateType).id=self.target->first().toString()) or (e.oclIsKindOf(scxml::ScxmlParallelType) and e.oclAsType(scxml::ScxmlParallelType).id=self.target->first().toString()) or (e.oclIsKindOf(scxml::ScxmlFinalType) and e.oclAsType(scxml::ScxmlFinalType).id=self.target->first().toString()))/]" sourceFinderExpression="feature:eContainer" domainClass="scxml.ScxmlTransitionType" useDomainElement="true">
+          <style targetArrow="InputFillClosedArrow" sizeComputationExpression="2">
+            <strokeColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
+            <centerLabelStyleDescription labelExpression="[(if (cond.oclIsUndefined() or cond='') then '' else ('['+cond+']')  endif) + event/]">
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            </centerLabelStyleDescription>
+          </style>
+        </edgeMappings>
+        <edgeMappings name="SubInitialTransition" sourceMapping="//@ownedViewpoints[name='SCXML']/@ownedRepresentations[name='Diagram']/@defaultLayer/@containerMappings[name='State']/@subNodeMappings[name='SubInitial']" targetMapping="//@ownedViewpoints[name='SCXML']/@ownedRepresentations[name='Diagram']/@defaultLayer/@containerMappings[name='State'] //@ownedViewpoints[name='SCXML']/@ownedRepresentations[name='Diagram']/@defaultLayer/@containerMappings[name='Parallel']" targetFinderExpression="[eContents()->select(e|(e.oclIsKindOf(scxml::ScxmlStateType) and e.oclAsType(scxml::ScxmlStateType).id=self.initial1->first().toString()) or (e.oclIsKindOf(scxml::ScxmlParallelType) and e.oclAsType(scxml::ScxmlParallelType).id=self.initial1->first().toString()))/]" sourceFinderExpression="[thisEObject/]" domainClass="scxml.ScxmlStateType" useDomainElement="true">
+          <style targetArrow="InputFillClosedArrow" sizeComputationExpression="2">
+            <strokeColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
+            <centerLabelStyleDescription>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            </centerLabelStyleDescription>
+          </style>
+        </edgeMappings>
+        <containerMappings name="State" labelDirectEdit="//@ownedViewpoints[name='SCXML']/@ownedRepresentations[name='Diagram']/@defaultLayer/@toolSections.0/@ownedTools[name='EditID']" semanticCandidatesExpression="[thisEObject.eContents()/]" domainClass="scxml.ScxmlStateType" reusedNodeMappings="//@ownedViewpoints[name='SCXML']/@ownedRepresentations[name='Diagram']/@defaultLayer/@nodeMappings[name='Final']" reusedContainerMappings="//@ownedViewpoints[name='SCXML']/@ownedRepresentations[name='Diagram']/@defaultLayer/@containerMappings[name='State'] //@ownedViewpoints[name='SCXML']/@ownedRepresentations[name='Diagram']/@defaultLayer/@containerMappings[name='Parallel'] //@ownedViewpoints[name='SCXML']/@ownedRepresentations[name='Diagram']/@defaultLayer/@containerMappings[name='Datamodel']">
+          <subNodeMappings name="SubInitial" preconditionExpression="[initial1.oclIsUndefined()->first()=false/]" semanticCandidatesExpression="[thisEObject/]" domainClass="scxml.ScxmlStateType">
+            <style xsi:type="style:EllipseNodeDescription" labelExpression="" resizeKind="NSEW">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
+            </style>
+          </subNodeMappings>
+          <style xsi:type="style:FlatContainerStyleDescription" arcWidth="10" arcHeight="10" borderSizeComputationExpression="1" labelExpression="feature:id" roundedCorner="true">
+            <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <backgroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='white']"/>
+            <foregroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='white']"/>
+          </style>
+        </containerMappings>
+        <containerMappings name="Parallel" labelDirectEdit="//@ownedViewpoints[name='SCXML']/@ownedRepresentations[name='Diagram']/@defaultLayer/@toolSections.0/@ownedTools[name='EditID']" semanticCandidatesExpression="[thisEObject.eContents()/]" domainClass="scxml.ScxmlParallelType" reusedContainerMappings="//@ownedViewpoints[name='SCXML']/@ownedRepresentations[name='Diagram']/@defaultLayer/@containerMappings[name='Parallel'] //@ownedViewpoints[name='SCXML']/@ownedRepresentations[name='Diagram']/@defaultLayer/@containerMappings[name='State'] //@ownedViewpoints[name='SCXML']/@ownedRepresentations[name='Diagram']/@defaultLayer/@containerMappings[name='Datamodel']">
+          <style xsi:type="style:FlatContainerStyleDescription" arcWidth="10" arcHeight="10" labelExpression="feature:id" roundedCorner="true">
+            <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='red']"/>
+            <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <backgroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='white']"/>
+            <foregroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='white']"/>
+          </style>
+        </containerMappings>
+        <containerMappings name="Datamodel" semanticCandidatesExpression="[thisEObject.eContents()/]" domainClass="scxml.ScxmlDatamodelType" childrenPresentation="List">
+          <subNodeMappings name="Data" labelDirectEdit="//@ownedViewpoints[name='SCXML']/@ownedRepresentations[name='Diagram']/@defaultLayer/@toolSections.0/@ownedTools[name='EditDataLabel']" semanticCandidatesExpression="feature:eAllContents" domainClass="scxml.ScxmlDataType">
+            <style xsi:type="style:SquareDescription" showIcon="false" labelExpression="[id + ' = ' + expr/]" resizeKind="NSEW">
+              <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
+            </style>
+          </subNodeMappings>
+          <style xsi:type="style:ShapeContainerStyleDescription" labelExpression="Datamodel">
+            <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <backgroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='light_yellow']"/>
+          </style>
+        </containerMappings>
+        <toolSections name="Tools">
+          <ownedTools xsi:type="tool:ContainerCreationDescription" name="StateCreation" containerMappings="//@ownedViewpoints[name='SCXML']/@ownedRepresentations[name='Diagram']/@defaultLayer/@containerMappings[name='State']">
+            <variable name="container"/>
+            <viewVariable name="containerView"/>
+            <initialOperation>
+              <firstModelOperations xsi:type="tool_1:CreateInstance" typeName="scxml.ScxmlStateType" referenceName="state" variableName="">
+                <subModelOperations xsi:type="tool_1:SetValue" featureName="id" valueExpression="['State' + eContainer(scxml::ScxmlScxmlType).eAllContents(scxml::ScxmlStateType)->size()/]"/>
+              </firstModelOperations>
+            </initialOperation>
+          </ownedTools>
+          <ownedTools xsi:type="tool:ContainerCreationDescription" name="ParallelCreation" containerMappings="//@ownedViewpoints[name='SCXML']/@ownedRepresentations[name='Diagram']/@defaultLayer/@containerMappings[name='Parallel']">
+            <variable name="container"/>
+            <viewVariable name="containerView"/>
+            <initialOperation>
+              <firstModelOperations xsi:type="tool_1:CreateInstance" typeName="scxml.ScxmlParallelType" referenceName="parallel" variableName="">
+                <subModelOperations xsi:type="tool_1:SetValue" featureName="id" valueExpression="['Parallel' + eContainer(scxml::ScxmlScxmlType).eAllContents(scxml::ScxmlParallelType)->size()/]"/>
+              </firstModelOperations>
+            </initialOperation>
+          </ownedTools>
+          <ownedTools xsi:type="tool:ContainerCreationDescription" name="DatamodelCreation" precondition="[eContents(scxml::ScxmlDatamodelType)->size()=0/]" containerMappings="//@ownedViewpoints[name='SCXML']/@ownedRepresentations[name='Diagram']/@defaultLayer/@containerMappings[name='Datamodel']">
+            <variable name="container"/>
+            <viewVariable name="containerView"/>
+            <initialOperation>
+              <firstModelOperations xsi:type="tool_1:CreateInstance" typeName="scxml.ScxmlDatamodelType" referenceName="datamodel"/>
+            </initialOperation>
+          </ownedTools>
+          <ownedTools xsi:type="tool:DirectEditLabel" name="EditID">
+            <mask mask="{0}"/>
+            <initialOperation>
+              <firstModelOperations xsi:type="tool_1:SetValue" featureName="id" valueExpression="var:0"/>
+            </initialOperation>
+          </ownedTools>
+          <ownedTools xsi:type="tool:NodeCreationDescription" name="DataCreation" nodeMappings="//@ownedViewpoints[name='SCXML']/@ownedRepresentations[name='Diagram']/@defaultLayer/@containerMappings[name='Datamodel']/@subNodeMappings[name='Data']">
+            <variable name="container"/>
+            <viewVariable name="containerView"/>
+            <initialOperation>
+              <firstModelOperations xsi:type="tool_1:CreateInstance" typeName="scxml.ScxmlDataType" referenceName="data">
+                <subModelOperations xsi:type="tool_1:SetValue" featureName="id" valueExpression="['var' + eContainer(scxml::ScxmlScxmlType).eAllContents(scxml::ScxmlDataType)->size()/]"/>
+                <subModelOperations xsi:type="tool_1:SetValue" featureName="expr" valueExpression="null"/>
+              </firstModelOperations>
+            </initialOperation>
+          </ownedTools>
+          <ownedTools xsi:type="tool:DirectEditLabel" name="EditDataLabel">
+            <mask mask="{0}"/>
+            <initialOperation>
+              <firstModelOperations xsi:type="tool_1:ChangeContext" browseExpression="[self/]">
+                <subModelOperations xsi:type="tool_1:SetValue" featureName="id" valueExpression="[getIdData(arg0,self.oclAsType(scxml::ScxmlDataType).id)/]"/>
+                <subModelOperations xsi:type="tool_1:SetValue" featureName="expr" valueExpression="[getExprData(arg0,self.oclAsType(scxml::ScxmlDataType).expr)/]"/>
+              </firstModelOperations>
+            </initialOperation>
+          </ownedTools>
+          <ownedTools xsi:type="tool:NodeCreationDescription" name="FinalCreation" nodeMappings="//@ownedViewpoints[name='SCXML']/@ownedRepresentations[name='Diagram']/@defaultLayer/@nodeMappings[name='Final']">
+            <variable name="container"/>
+            <viewVariable name="containerView"/>
+            <initialOperation>
+              <firstModelOperations xsi:type="tool_1:CreateInstance" typeName="scxml.ScxmlFinalType" referenceName="final">
+                <subModelOperations xsi:type="tool_1:SetValue" featureName="id" valueExpression="['final' + eContainer(scxml::ScxmlScxmlType).eAllContents(scxml::ScxmlFinalType)->size()/]"/>
+              </firstModelOperations>
+            </initialOperation>
+          </ownedTools>
+          <ownedTools xsi:type="tool_1:OperationAction" name="SetInitial" label="Define as initial" precondition="[(oclIsKindOf(scxml::ScxmlStateType) or oclIsKindOf(scxml::ScxmlParallelType)) and eContainer().oclIsKindOf(scxml::ScxmlScxmlType)/]">
+            <view name="views">
+              <subVariables xsi:type="tool_1:AcceleoVariable" name="nameInitial" computationExpression="[(if self.target.oclIsKindOf(scxml::ScxmlStateType) then self.target.oclAsType(scxml::ScxmlStateType).id else self.target.oclAsType(scxml::ScxmlParallelType).id endif)/]"/>
+            </view>
+            <initialOperation>
+              <firstModelOperations xsi:type="tool_1:ChangeContext" browseExpression="[eContainer().oclAsType(scxml::ScxmlScxmlType)/]">
+                <subModelOperations xsi:type="tool_1:SetValue" featureName="initial" valueExpression="var:nameInitial"/>
+              </firstModelOperations>
+            </initialOperation>
+          </ownedTools>
+          <ownedTools xsi:type="tool_1:OperationAction" name="SetSubInitial" label="Define as initial" precondition="[(oclIsKindOf(scxml::ScxmlStateType) or oclIsKindOf(scxml::ScxmlParallelType)) and eContainer().oclIsKindOf(scxml::ScxmlStateType)/]">
+            <view name="views">
+              <subVariables xsi:type="tool_1:AcceleoVariable" name="nameInitial" computationExpression="[(if self.target.oclIsKindOf(scxml::ScxmlStateType) then self.target.oclAsType(scxml::ScxmlStateType).id else self.target.oclAsType(scxml::ScxmlParallelType).id endif)/]"/>
+            </view>
+            <initialOperation>
+              <firstModelOperations xsi:type="tool_1:ChangeContext" browseExpression="[eContainer().oclAsType(scxml::ScxmlStateType)/]">
+                <subModelOperations xsi:type="tool_1:SetValue" featureName="initial1" valueExpression="var:nameInitial"/>
+              </firstModelOperations>
+            </initialOperation>
+          </ownedTools>
+          <ownedTools xsi:type="tool:EdgeCreationDescription" name="TransitionCreation" edgeMappings="//@ownedViewpoints[name='SCXML']/@ownedRepresentations[name='Diagram']/@defaultLayer/@edgeMappings[name='Transition']">
+            <sourceVariable name="sourceObj"/>
+            <targetVariable name="targetObj"/>
+            <sourceViewVariable name="sourceView"/>
+            <targetViewVariable name="targetView"/>
+            <initialOperation>
+              <firstModelOperations xsi:type="tool_1:CreateInstance" typeName="scxml.ScxmlTransitionType" referenceName="transition">
+                <subModelOperations xsi:type="tool_1:Switch">
+                  <cases conditionExpression="[targetObj.oclIsKindOf(scxml::ScxmlParallelType)/]">
+                    <subModelOperations xsi:type="tool_1:SetValue" featureName="target" valueExpression="[targetObj.oclAsType(scxml::ScxmlParallelType).id/]"/>
+                  </cases>
+                  <cases conditionExpression="[targetObj.oclIsKindOf(scxml::ScxmlFinalType)/]">
+                    <subModelOperations xsi:type="tool_1:SetValue" featureName="target" valueExpression="[targetObj.oclAsType(scxml::ScxmlFinalType).id/]"/>
+                  </cases>
+                  <default>
+                    <subModelOperations xsi:type="tool_1:SetValue" featureName="target" valueExpression="[targetObj.oclAsType(scxml::ScxmlStateType).id/]"/>
+                  </default>
+                </subModelOperations>
+              </firstModelOperations>
+            </initialOperation>
+          </ownedTools>
+          <ownedTools xsi:type="tool:DirectEditLabel" name="EditTransitionLabel">
+            <mask mask="{0}"/>
+            <initialOperation>
+              <firstModelOperations xsi:type="tool_1:ChangeContext" browseExpression="[self/]">
+                <subModelOperations xsi:type="tool_1:SetValue" featureName="event" valueExpression="[getEventTransition(arg0,self.oclAsType(scxml::ScxmlTransitionType).event)/]"/>
+                <subModelOperations xsi:type="tool_1:SetValue" featureName="cond" valueExpression="[getCondTransition(arg0,self.oclAsType(scxml::ScxmlTransitionType).cond)/]"/>
+              </firstModelOperations>
+            </initialOperation>
+          </ownedTools>
+        </toolSections>
+      </defaultLayer>
+    </ownedRepresentations>
+    <ownedJavaExtensions qualifiedClassName="scxmlDiagram.design.LabelParser"/>
+  </ownedViewpoints>
+</description:Group>

--- a/SCXMLDiagram.design/plugin.xml
+++ b/SCXMLDiagram.design/plugin.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.0"?>
+<plugin>
+  <extension point="org.eclipse.sirius.componentization">
+    <component class="scxmlDiagram.design.Activator"
+               id="scxml1.design"
+	       name="scxml1">
+    </component>
+  </extension>
+</plugin>

--- a/SCXMLDiagram.design/representations.aird
+++ b/SCXMLDiagram.design/representations.aird
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<viewpoint:DAnalysis xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:viewpoint="http://www.eclipse.org/sirius/1.1.0" xmi:id="_azjGULd_EeS3S7atp2Pm7w" version="8.1.1"/>

--- a/SCXMLDiagram.design/src/scxmlDiagram/design/Activator.java
+++ b/SCXMLDiagram.design/src/scxmlDiagram/design/Activator.java
@@ -1,0 +1,66 @@
+package scxmlDiagram.design;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.sirius.business.api.componentization.ViewpointRegistry;
+import org.eclipse.sirius.viewpoint.description.Viewpoint;
+import org.eclipse.ui.plugin.AbstractUIPlugin;
+import org.osgi.framework.BundleContext;
+
+/**
+ * The activator class controls the plug-in life cycle
+ */
+public class Activator extends AbstractUIPlugin {
+    // The plug-in ID
+    public static final String PLUGIN_ID = "scxml1.design";
+
+    // The shared instance
+    private static Activator plugin;
+
+    private static Set<Viewpoint> viewpoints; 
+
+    /**
+     * The constructor
+     */
+    public Activator() {
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.eclipse.ui.plugin.AbstractUIPlugin#start(org.osgi.framework.BundleContext)
+     */
+    public void start(BundleContext context) throws Exception {
+      super.start(context);
+	  plugin = this;
+	  viewpoints = new HashSet<Viewpoint>();
+	  viewpoints.addAll(ViewpointRegistry.getInstance().registerFromPlugin(PLUGIN_ID + "/description/scxml1.odesign")); 
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.eclipse.ui.plugin.AbstractUIPlugin#stop(org.osgi.framework.BundleContext)
+     */
+    public void stop(BundleContext context) throws Exception {
+	plugin = null;
+	if (viewpoints != null) {
+	    for (final Viewpoint viewpoint: viewpoints) {
+		ViewpointRegistry.getInstance().disposeFromPlugin(viewpoint);
+	    }
+	    viewpoints.clear();
+	    viewpoints = null; 
+	}
+	super.stop(context);
+    }
+
+    /**
+     * Returns the shared instance
+     * 
+     * @return the shared instance
+     */
+    public static Activator getDefault() {
+	return plugin;
+    }
+}

--- a/SCXMLDiagram.design/src/scxmlDiagram/design/LabelParser.java
+++ b/SCXMLDiagram.design/src/scxmlDiagram/design/LabelParser.java
@@ -1,0 +1,65 @@
+package scxmlDiagram.design;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.w3._2005._07.scxml.ScxmlDataType;
+import org.w3._2005._07.scxml.ScxmlTransitionType;
+
+
+public class LabelParser {
+	// transition labels are in the form : "[cond]event" where [cond] and event are optionnal
+	private static String REGEX1 = "^(\\s*\\[\\s*\\w+\\s*\\])?\\s*[\\w\\.]*\\s*$";
+	// data labels are in the form : "id=expr"
+	private static String REGEX2 = "^\\s*\\w+\\s*=\\s*\\w+\\s*$";
+	
+	public LabelParser(){}
+	
+	public String getEventTransition(ScxmlTransitionType obj, String label, String oldEvent){
+		String ret = oldEvent;
+		Pattern p = Pattern.compile(REGEX1);
+		Matcher m = p.matcher(label);
+		if (m.matches()){
+			String event = label.substring(label.indexOf("]")+1);
+			ret = event.trim();
+		}
+		return ret;
+	}
+	
+	public String getCondTransition(ScxmlTransitionType obj, String label, String oldCond){
+		String ret = oldCond;
+		Pattern p = Pattern.compile(REGEX1);
+		Matcher m = p.matcher(label);
+		if (m.matches()){
+			if (label.indexOf("[")<0){
+				ret = "";
+			}
+			else{
+				String cond = label.substring(label.indexOf("[")+1, label.indexOf("]"));
+				ret = cond.trim();
+			}
+		}
+		return ret;
+	}
+	
+	public String getIdData(ScxmlDataType obj, String label, String oldId){
+		String ret = oldId;
+		Pattern p = Pattern.compile(REGEX2);
+		Matcher m = p.matcher(label);
+		if (m.matches()){
+			String id = label.substring(0, label.indexOf("="));
+			ret = id.trim();
+		}
+		return ret;
+	}
+	
+	public String getExprData(ScxmlDataType obj, String label, String oldExpr){
+		String ret = oldExpr;
+		Pattern p = Pattern.compile(REGEX2);
+		Matcher m = p.matcher(label);
+		if (m.matches()){
+			String expr = label.substring(label.indexOf("=")+1);
+			ret = expr.trim();
+		}
+		return ret;
+	}
+}


### PR DESCRIPTION
Contains a prototype odesign file (SCXMLDiagram.odesign) that permits to represent SXCML files in a diagram representation (with some tools to modify them) and a java service (LabelParser.java) used for editing transition labels and data labels.
